### PR TITLE
Add support for passing web browser URL to TV via Websocket.

### DIFF
--- a/addons/binding/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/protocol/RemoteControllerWebSocket.java
+++ b/addons/binding/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/protocol/RemoteControllerWebSocket.java
@@ -340,7 +340,9 @@ public class RemoteControllerWebSocket extends RemoteController implements Liste
     }
 
     public void sendUrl(String url) {
-        webSocketRemote.sendSourceApp("org.tizen.browser", false);
+        String processedUrl = url.replace("/", "\\/");
+        webSocketRemote.sendSourceApp("org.tizen.browser", false, processedUrl);
+    }
     }
 
     public List<String> getAppList() {

--- a/addons/binding/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/protocol/WebSocketRemote.java
+++ b/addons/binding/org.openhab.binding.samsungtv/src/main/java/org/openhab/binding/samsungtv/internal/protocol/WebSocketRemote.java
@@ -151,10 +151,17 @@ class WebSocketRemote extends WebSocketBase {
             params.data.action_type = deepLink ? "DEEP_LINK" : "NATIVE_LAUNCH";
         }
 
+        public JSONSourceApp(String appName, boolean deepLink, String metaTag) {
+            params.data.appId = appName;
+            params.data.action_type = deepLink ? "DEEP_LINK" : "NATIVE_LAUNCH";
+            params.data.metaTag = metaTag;
+        }
+
         static class Params {
             static class Data {
                 String appId;
                 String action_type;
+                String metaTag;
             }
 
             String event = "ed.apps.launch";
@@ -170,6 +177,10 @@ class WebSocketRemote extends WebSocketBase {
 
     public void sendSourceApp(String appName, boolean deepLink) {
         sendCommand(remoteControllerWebSocket.gson.toJson(new JSONSourceApp(appName, deepLink)));
+    }
+
+    public void sendSourceApp(String appName, boolean deepLink, String metaTag) {
+        sendCommand(remoteControllerWebSocket.gson.toJson(new JSONSourceApp(appName, deepLink, metaTag)));
     }
 
     static class JSONRemoteControl {


### PR DESCRIPTION
Hi Arjan,

I've added support for launching the web browser with the URL provided via Web Socket. I see this support was not present and it only launched the browser in web socket mode.

Signed-off-by: Stewart Cossey <stewart.cossey@gmail.com> (github: Cossey)